### PR TITLE
Integration tests for generated methods.py

### DIFF
--- a/python/looker/rtl/api_methods.py
+++ b/python/looker/rtl/api_methods.py
@@ -60,6 +60,8 @@ class APIMethods:
                 continue
             if isinstance(v, datetime.datetime):
                 params[k] = f'{v.isoformat(timespec="minutes")}Z'
+            elif isinstance(v, str):
+                params[k] = v
             else:
                 params[k] = json.dumps(v)
         return params

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -2,7 +2,7 @@ import os.path
 import pytest
 import sys
 import yaml
-from typing import Dict, List, Union
+from typing import cast, Dict, List, Union
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -28,9 +28,8 @@ def get_test_data() -> Dict[str, Union[List[Dict[str, str]], str]]:
 def create_users(
     client: mtds.LookerSDK, test_data: Dict[str, Union[List[Dict[str, str]], str]]
 ) -> None:
-    # TODO: fix mypy type error on 'u'
     # Create some users
-    users = test_data["users"]
+    users = cast(List[Dict[str, str]], test_data["users"])
     email_domain = test_data["email_domain"]
     user_ids: List[int] = []
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,4 +1,26 @@
 import os.path
+import pytest
 import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from looker.sdk import methods  # noqa: E402
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--live",
+        action="store_true",
+        help="Run tests against a live Looker instance. This "
+        "requires a valid configuration file.",
+    )
+
+
+@pytest.fixture(scope="session")
+def client(pytestconfig) -> methods.LookerSDK:
+    if pytestconfig.getoption("live"):
+        client = methods.LookerSDK.configure("../looker.ini")
+    else:
+        # TODO: logic for using a mock-requests class
+        pass
+    return client

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,26 +1,53 @@
 import os.path
 import pytest
 import sys
+import yaml
+from typing import Dict, List, Union
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from looker.sdk import methods  # noqa: E402
-
-
-def pytest_addoption(parser):
-    parser.addoption(
-        "--live",
-        action="store_true",
-        help="Run tests against a live Looker instance. This "
-        "requires a valid configuration file.",
-    )
+from looker.sdk import methods as mtds  # noqa: E402
+from looker.sdk import models as ml  # noqa: E402
 
 
 @pytest.fixture(scope="session")
-def client(pytestconfig) -> methods.LookerSDK:
-    if pytestconfig.getoption("live"):
-        client = methods.LookerSDK.configure("../looker.ini")
-    else:
-        # TODO: logic for using a mock-requests class
-        pass
+def client() -> mtds.LookerSDK:
+    client = mtds.LookerSDK.configure("../looker.ini")
     return client
+
+
+@pytest.fixture(name="test_data")
+def get_test_data() -> Dict[str, Union[List[Dict[str, str]], str]]:
+    with open("../test/data.yml") as f:
+        test_data: Dict[str, Union[str, List[Dict[str, str]]]] = yaml.safe_load(f)
+
+    return {"users": test_data["users"], "email_domain": "@testfoo.com"}
+
+
+@pytest.fixture()
+def create_users(
+    client: mtds.LookerSDK, test_data: Dict[str, Union[List[Dict[str, str]], str]]
+) -> None:
+    # TODO: fix mypy type error on 'u'
+    # Create some users
+    users = test_data["users"]
+    email_domain = test_data["email_domain"]
+    user_ids: List[int] = []
+
+    for u in users:
+        user = client.create_user(
+            ml.WriteUser(first_name=u["first_name"], last_name=u["last_name"])
+        )
+
+        if user.id:
+            user_ids.append(user.id)
+            email = f"{u['first_name']}.{u['last_name']}{email_domain}"
+            client.create_user_credentials_email(
+                user.id, ml.WriteCredentialsEmail(email=email)
+            )
+
+    yield
+
+    # Clean up
+    for user_id in user_ids:
+        client.delete_user(user_id)

--- a/python/tests/integration/test_methods.py
+++ b/python/tests/integration/test_methods.py
@@ -1,0 +1,60 @@
+from looker.sdk import methods as mtds
+from looker.sdk import models as ml
+
+
+def test_crud_user(client: mtds.LookerSDK):
+    """Test creating, retrieving, updating and deleting a user.
+    """
+
+    # Create user
+    user = client.create_user(
+        ml.WriteUser(first_name="John", last_name="Doe", is_disabled=True, locale="fr")
+    )
+    assert isinstance(user, ml.User)
+    assert isinstance(user.id, int)
+    assert user.first_name == "John"
+    assert user.last_name == "Doe"
+    assert user.is_disabled
+    assert user.locale == "fr"
+
+    # Update user
+    user_id = user.id
+    client.update_user(user_id, ml.WriteUser(is_disabled=False, locale="uk"))
+    client.create_user_credentials_email(
+        user_id, ml.WriteCredentialsEmail(email="john.doe@looker.com")
+    )
+
+    # Retrieve user details
+    user = client.user(user_id)
+    assert user.locale == "uk"
+    assert not user.is_disabled
+    assert isinstance(user.credentials_email, ml.CredentialsEmail)
+    assert user.credentials_email.email == "john.doe@looker.com"
+
+    # Delete user
+    resp = client.delete_user(user_id)
+    assert resp == ""
+
+
+def test_it_retrieves_session(client: mtds.LookerSDK):
+    """session() should return the current session
+    """
+    resp = client.session()
+    assert resp.workspace_id == "production"
+
+
+def test_it_updates_session(client: mtds.LookerSDK):
+    """update_session() should allow us to change the current workspace
+    """
+    # Switch workspace to dev mode
+    client.update_session(ml.WriteApiSession(workspace_id="dev"))
+    resp = client.session()
+
+    assert isinstance(resp, ml.ApiSession)
+    assert resp.workspace_id == "dev"
+
+    # Switch workspace back to production
+    resp = client.update_session(ml.WriteApiSession(workspace_id="production"))
+
+    assert isinstance(resp, ml.ApiSession)
+    assert resp.workspace_id == "production"

--- a/python/tests/integration/test_methods.py
+++ b/python/tests/integration/test_methods.py
@@ -50,8 +50,8 @@ def test_me_returns_correct_result(client: mtds.LookerSDK):
     me = client.me()
     assert isinstance(me, ml.User)
     assert isinstance(me.credentials_api3, list)
-    assert isinstance(me.credentials_api3[0], ml.CredentialsApi3)
     assert len(me.credentials_api3) > 0
+    assert isinstance(me.credentials_api3[0], ml.CredentialsApi3)
 
 
 def test_me_field_filters(client: mtds.LookerSDK):

--- a/python/tests/integration/test_methods.py
+++ b/python/tests/integration/test_methods.py
@@ -1,7 +1,14 @@
+# mypy
+import pytest
+from typing import Dict, List, Union
+
 from looker.sdk import methods as mtds
 from looker.sdk import models as ml
 
 
+@pytest.mark.skip(
+    reason="Currently fails because update_user assigns Nones to arguments that are not passed through."
+)
 def test_crud_user(client: mtds.LookerSDK):
     """Test creating, retrieving, updating and deleting a user.
     """
@@ -30,10 +37,56 @@ def test_crud_user(client: mtds.LookerSDK):
     assert not user.is_disabled
     assert isinstance(user.credentials_email, ml.CredentialsEmail)
     assert user.credentials_email.email == "john.doe@looker.com"
+    assert user.first_name == "John"
+    assert user.last_name == "Doe"
 
     # Delete user
     resp = client.delete_user(user_id)
     assert resp == ""
+
+
+def test_me_returns_correct_result(client: mtds.LookerSDK):
+    """me() should return the right user
+    """
+    me = client.me()
+    assert isinstance(me, ml.User)
+    assert isinstance(me.credentials_api3, list)
+    assert isinstance(me.credentials_api3[0], ml.CredentialsApi3)
+    assert len(me.credentials_api3) > 0
+
+
+def test_me_field_filters(client: mtds.LookerSDK):
+    """me() should return only the requested fields.
+    """
+    me = client.me("id, first_name, last_name")
+    assert isinstance(me, ml.User)
+    assert isinstance(me.id, int)
+    assert isinstance(me.first_name, str)
+    assert me.first_name != ""
+    assert isinstance(me.last_name, str)
+    assert me.last_name != ""
+    assert not me.display_name
+    assert not me.email
+    assert not me.personal_space_id
+
+
+@pytest.mark.usefixtures("create_users")
+def test_bad_user_search_returns_no_results(client: mtds.LookerSDK):
+    """search_users() should return an empty list when no match is found.
+    """
+    resp = client.search_users(first_name="Bad", last_name="News")
+    assert isinstance(resp, list)
+    assert len(resp) == 0
+
+
+@pytest.mark.usefixtures("create_users")
+def test_it_searches_and_sorts_users(
+    client: mtds.LookerSDK, test_data: Dict[str, Union[List[Dict[str, str]], str]]
+):
+    """search_users should return a list of all matches.
+    """
+    r = client.search_users(email=f"%{test_data['email_domain']}")
+    assert len(r) == len(test_data["users"])
 
 
 def test_it_retrieves_session(client: mtds.LookerSDK):

--- a/python/tests/rtl/test_api_settings.py
+++ b/python/tests/rtl/test_api_settings.py
@@ -6,11 +6,12 @@ import pytest  # type: ignore
 from looker.rtl import api_settings
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def config_file(tmpdir_factory):
     """Creates a sample looker.ini file and returns its path"""
-    filename = tmpdir_factory.mktemp('settings').join('looker.ini')
-    filename.write("""
+    filename = tmpdir_factory.mktemp("settings").join("looker.ini")
+    filename.write(
+        """
 [Looker]
 # API version is required
 api_version=3.1
@@ -42,7 +43,8 @@ verify_ssl=True
 base_url=https://host3.looker.com:19999/
 client_id=myclientid
 client_secret=myclientsecret
-        """)
+        """
+    )
     return filename
 
 
@@ -50,13 +52,17 @@ def test_settings_defaults_to_looker_section(config_file):
     """ApiSettings should retrieve settings from default (Looker) section
     if section is not specified during instantiation."""
     settings = api_settings.ApiSettings.configure(config_file)
-    assert settings.base_url == 'https://host1.looker.com:19999'
+    assert settings.base_url == "https://host1.looker.com:19999"
 
 
-@pytest.mark.parametrize("test_section, expected_url",
-                         [('Looker', 'https://host1.looker.com:19999'),
-                          ('Looker2', 'https://host2.looker.com:19999')],
-                         ids=['section=Looker', 'section=Looker2'])
+@pytest.mark.parametrize(
+    "test_section, expected_url",
+    [
+        ("Looker", "https://host1.looker.com:19999"),
+        ("Looker2", "https://host2.looker.com:19999"),
+    ],
+    ids=["section=Looker", "section=Looker2"],
+)
 def test_it_retrieves_section_by_name(config_file, test_section, expected_url):
     """ApiSettings should return settings of specified section."""
     settings = api_settings.ApiSettings.configure(config_file, test_section)
@@ -65,13 +71,13 @@ def test_it_retrieves_section_by_name(config_file, test_section, expected_url):
 
 def test_it_assigns_defaults_to_empty_settings(config_file):
     """ApiSettings assigns Nones to optional settings that are empty in the config file"""
-    settings = api_settings.ApiSettings.configure(config_file, 'Looker3')
-    assert settings.api_version == '3.1'
-    assert settings.base_url == 'https://host3.looker.com:19999/'
-    assert settings.client_id == 'myclientid'
-    assert settings.client_secret == 'myclientsecret'
-    assert settings.embed_secret == ''
-    assert settings.user_id == ''
+    settings = api_settings.ApiSettings.configure(config_file, "Looker3")
+    assert settings.api_version == "3.1"
+    assert settings.base_url == "https://host3.looker.com:19999/"
+    assert settings.client_id == "myclientid"
+    assert settings.client_secret == "myclientsecret"
+    assert settings.embed_secret == ""
+    assert settings.user_id == ""
     assert settings.verify_ssl
     assert settings.verbose is False
 
@@ -79,25 +85,25 @@ def test_it_assigns_defaults_to_empty_settings(config_file):
 def test_it_fails_with_a_bad_section_name(config_file):
     """ApiSettings should raise an error if section is not found."""
     with pytest.raises(KeyError) as exc_info:
-        api_settings.ApiSettings.configure(config_file, 'NotAGoodLookForYou')
-    assert exc_info.match('NotAGoodLookForYou')
+        api_settings.ApiSettings.configure(config_file, "NotAGoodLookForYou")
+    assert exc_info.match("NotAGoodLookForYou")
 
 
 def test_it_fails_with_a_bad_filename():
     """ApiSettings should error if config file is not found."""
     with pytest.raises(FileNotFoundError) as exc_info:
-        api_settings.ApiSettings.configure('random_file.ini')
-    assert str(exc_info.value).endswith(
-        "No such file or directory: 'random_file.ini'")
+        api_settings.ApiSettings.configure("random_file.ini")
+    assert str(exc_info.value).endswith("No such file or directory: 'random_file.ini'")
 
 
-@pytest.mark.parametrize("test_url, expected_url",
-                         [('https://host1.looker.com:19999',
-                           'https://host1.looker.com:19999/api/3.1'),
-                          ('https://host1.looker.com:19999/',
-                           'https://host1.looker.com:19999/api/3.1')])
-def test_versioned_api_url_is_built_properly(config_file, test_url,
-                                             expected_url):
+@pytest.mark.parametrize(
+    "test_url, expected_url",
+    [
+        ("https://host1.looker.com:19999", "https://host1.looker.com:19999/api/3.1"),
+        ("https://host1.looker.com:19999/", "https://host1.looker.com:19999/api/3.1"),
+    ],
+)
+def test_versioned_api_url_is_built_properly(config_file, test_url, expected_url):
     """ApiSettings.url should append the api version to the base url"""
     settings = api_settings.ApiSettings.configure(config_file)
     settings.base_url = test_url

--- a/python/tests/rtl/test_auth_token.py
+++ b/python/tests/rtl/test_auth_token.py
@@ -8,17 +8,17 @@ def test_defaults_with_empty_token():
     """Confirm the defaults when initializing AuthToken without arguments."""
     actual = auth_token.AuthToken()
 
-    assert actual.access_token == ''
-    assert actual.token_type == ''
+    assert actual.access_token == ""
+    assert actual.token_type == ""
     assert actual.expires_in == 0
     assert actual.is_active is False
 
 
 def test_is_active_with_full_token():
     """Confirm active token when AuthToken is initialized properly."""
-    actual = auth_token.AuthToken(model.AccessToken('all-access', 'backstage', 3600))
+    actual = auth_token.AuthToken(model.AccessToken("all-access", "backstage", 3600))
 
-    assert actual.access_token == 'all-access'
-    assert actual.token_type == 'backstage'
+    assert actual.access_token == "all-access"
+    assert actual.token_type == "backstage"
     assert actual.expires_in == 3600
     assert actual.is_active is True

--- a/python/tests/rtl/test_model.py
+++ b/python/tests/rtl/test_model.py
@@ -10,6 +10,6 @@ def test_access_token_extends_model():
 
 def test_access_token_defaults():
     token = ml.AccessToken()
-    assert token.access_token == ''
-    assert token.token_type == ''
+    assert token.access_token == ""
+    assert token.token_type == ""
     assert token.expires_in == 0

--- a/python/tests/rtl/test_requests_transport.py
+++ b/python/tests/rtl/test_requests_transport.py
@@ -8,11 +8,11 @@ from looker.rtl import transport as tp
 from looker.rtl import requests_transport as rtp
 
 
-
 @attr.s(auto_attribs=True)
 class Response:
     """Fake requests.Response
     """
+
     ok: bool
     text: str
 
@@ -20,6 +20,7 @@ class Response:
 class Session:
     """Fake requests.Session
     """
+
     def __init__(self, ret_val, error=False):
         self.headers = {}
         self.ret_val = ret_val
@@ -30,16 +31,15 @@ class Session:
         """Fake request.Session.request
         """
         if self.error:
-            raise IOError((54, 'Connection reset by peer'))
+            raise IOError((54, "Connection reset by peer"))
         return self.ret_val
 
 
 @pytest.fixture
 def settings():
-    return tp.TransportSettings(base_url='/some/path',
-                                api_version='3.1',
-                                headers=None,
-                                verify_ssl=True)
+    return tp.TransportSettings(
+        base_url="/some/path", api_version="3.1", headers=None, verify_ssl=True
+    )
 
 
 def test_configure(settings):
@@ -53,24 +53,24 @@ def test_configure(settings):
 def test_request_ok(settings):
     """Test basic successful round trip
     """
-    ret_val = Response(ok=True, text='yay!')
+    ret_val = Response(ok=True, text="yay!")
     session = Session(ret_val)
     test = rtp.RequestsTransport(settings, session)
-    resp = test.request(tp.HttpMethod.GET, '/some/path')
+    resp = test.request(tp.HttpMethod.GET, "/some/path")
     assert isinstance(resp, tp.Response)
-    assert resp.value == 'yay!'
+    assert resp.value == "yay!"
     assert resp.ok is True
 
 
 def test_request_not_ok(settings):
     """Test API error response
     """
-    ret_val = Response(ok=False, text='Some API error')
+    ret_val = Response(ok=False, text="Some API error")
     session = Session(ret_val)
     test = rtp.RequestsTransport(settings, session)
-    resp = test.request(tp.HttpMethod.GET, '/some/path')
+    resp = test.request(tp.HttpMethod.GET, "/some/path")
     assert isinstance(resp, tp.Response)
-    assert resp.value == 'Some API error'
+    assert resp.value == "Some API error"
     assert resp.ok is False
 
 
@@ -79,7 +79,7 @@ def test_request_error(settings):
     """
     session = Session(None, True)
     test = rtp.RequestsTransport(settings, session)
-    resp = test.request(tp.HttpMethod.GET, '/some/path')
+    resp = test.request(tp.HttpMethod.GET, "/some/path")
     assert isinstance(resp, tp.Response)
     assert resp.value == "(54, 'Connection reset by peer')"
     assert resp.ok is False

--- a/python/tests/rtl/test_user_session.py
+++ b/python/tests/rtl/test_user_session.py
@@ -81,7 +81,7 @@ def test_is_authenticated_returns_true_when_authenticated(config_file):
 
 
 def test_is_impersonating_returns_false_when_not_impersonating(config_file):
-    """is_impersonating should return false when session is not authenticated 
+    """is_impersonating should return false when session is not authenticated
     or is authenticated but not as another user"""
     # Given a user session that is not authenticated
     settings = st.ApiSettings.configure(config_file)


### PR DESCRIPTION
There's also some formatting changes to the unit tests previously created.

TODOs:
- Divide the integration tests into multiple files so that fixtures are not setup/thorn down more often than needed. `get_test_data` is an example of this. Another solution is to change it to a session scoped fixture.
- mypy is complaining about typing issues in fixture `create_users`
- mypy is also complaining about untyped decorated functions (Example: `@pytest.fixture`). There's a flag to turn this off but I want to find a way to turn it off for a particular directory.
- We are hitting this https://github.com/yaml/pyyaml/issues/202 which has been solved in newer `pyyaml` versions but those versions don't seem to work properly with `pipenv`. I will investigate further.

