### PR TITLE
Run black on python generated code

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+black = "*"
+
+[requires]
+python_version = "3.7"
+
+[pipenv]
+allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,57 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "b132de3bc6e041e3fa5ab7a0feb2ee862f488ae8903790188641b70b5e595abd"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "appdirs": {
+            "hashes": [
+                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
+                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+            ],
+            "version": "==1.4.3"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf",
+                "sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c"
+            ],
+            "index": "pypi",
+            "version": "==19.3b0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+            ],
+            "version": "==7.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+            ],
+            "version": "==0.10.0"
+        }
+    },
+    "develop": {}
+}

--- a/convert.ts
+++ b/convert.ts
@@ -32,7 +32,7 @@ import { fail, log, quit, run } from './utils'
 const lintCheck = async (fileName: string) => {
   // TODO skip if flag to ignore lint errors is specified
   try {
-    const linter = await run('speccy', ['lint', fileName])
+    const linter = run('speccy', ['lint', fileName])
     if (!linter) return fail('Lint', 'no response')
     if (linter.toString().indexOf('Specification is valid, with 0 lint errors') >= 0) return
     return fail('Lint', linter.toString())
@@ -52,8 +52,8 @@ const convertSpec = async (fileName: string, openApiFile: string) => {
     // patch to fix up small errors in source definition (not required, just to ensure smooth process)
     // indent 2 spaces
     // output to openApiFile
-    // await run('swagger2openapi', [fileName, '--resolveInternal', '-p', '-i', '"  "', '-o', openApiFile])
-    await run('swagger2openapi', [fileName, '-p', '-i', '"  "', '-o', openApiFile])
+    // run('swagger2openapi', [fileName, '--resolveInternal', '-p', '-i', '"  "', '-o', openApiFile])
+    run('swagger2openapi', [fileName, '-p', '-i', '"  "', '-o', openApiFile])
     if (!fs.existsSync(openApiFile)) return fail('convertSpec', `creating ${openApiFile} failed`)
     return openApiFile
   } catch (e) {

--- a/python.fmt.ts
+++ b/python.fmt.ts
@@ -26,6 +26,7 @@
 
 import { Arg, IMappedType, IMethod, IParameter, IProperty, IType, strBody } from './sdkModels'
 import { CodeFormatter, warnEditing } from './codeFormatter'
+import { run } from './utils'
 
 export class PythonFormatter extends CodeFormatter {
   codePath = './python/'
@@ -342,17 +343,14 @@ ${this.hooks.join('\n')}
     return this._typeMap(type, 'models')
   }
 
-  // TODO add support for calling black to format the python file
   // @ts-ignore
   reformatFile(fileName: string) {
-    // const name = super.reformatFile(fileName)
-    // if (name) {
-    //   const source = prettier.format(fs.readFileSync(name, utf8))
-    //   if (source) {
-    //     fs.writeFileSync(name, source, {encoding: utf8})
-    //     return name
-    //   }
-    // }
+    const name = super.reformatFile(fileName)
+    if (name) {
+      run('command', ['-v', 'pipenv'], 'please install pipenv: https://docs.pipenv.org/en/latest/install/#installing-pipenv')
+      run('pipenv', ['update'])
+      run('pipenv',  ['run', 'black', `${this.codePath}/${this.packagePath}/sdk/`])
+    }
     return ''
   }
 

--- a/utils.ts
+++ b/utils.ts
@@ -61,7 +61,7 @@ export const fail = (name: string, message: string) => {
   return quit(err)
 }
 
-export const run = async (command: string, args: string[]) => {
+export const run = (command: string, args: string[], errMsg?: string) => {
   // https://nodejs.org/api/child_process.html#child_process_child_process_execsync_command_options
   const options = {
     maxBuffer: 1024 * 2048,
@@ -75,7 +75,7 @@ export const run = async (command: string, args: string[]) => {
     const result = execSync(command, options)
     return result
   } catch (e) {
-    return quit(e)
+    return quit(errMsg || e)
   }
 }
 


### PR DESCRIPTION
Format the generated code as cleanly as possible using black
- Uses pipenv to install/update black and run it
- slight refactor on utils.run - no need for async and custom error