### PR TITLE
Codegen: set required attribute of Property

### DIFF
--- a/sdkModels.spec.ts
+++ b/sdkModels.spec.ts
@@ -26,6 +26,26 @@ describe('sdkModels', () => {
 
   })
 
+  describe('required properties', () => {
+
+    it('CreateQueryTask', () => {
+      const type = apiModel.types['CreateQueryTask']
+      const actual = apiModel.getWriteableType(type)
+      expect(actual).toBeDefined()
+      expect(type.properties['query_id'].required).toEqual(true)
+      expect(type.properties['result_format'].required).toEqual(true)
+      expect(type.properties['source'].required).toEqual(false)
+    })
+
+    it('WriteCreateQueryTask', () => {
+      const type = apiModel.getWriteableType(apiModel.types['CreateQueryTask'])
+      expect(type).toBeDefined()
+      expect(type!.properties['query_id'].required).toEqual(true)
+      expect(type!.properties['result_format'].required).toEqual(true)
+      expect(type!.properties['source'].required).toEqual(false)
+    })
+  })
+
   describe('writeable logic', () => {
 
     it('CredentialsApi3', () => {

--- a/typescript/looker/test/methods.spec.ts
+++ b/typescript/looker/test/methods.spec.ts
@@ -182,7 +182,7 @@ describe('LookerSDK', () => {
       const apiUser = await sdk.ok(sdk.me())
       let all = await sdk.ok(
         sdk.all_users({
-          fields: 'id'
+          fields: 'id,is_disabled'
         })
       )
 


### PR DESCRIPTION
Per the "Required Properties" section of
https://swagger.io/docs/specification/data-models/data-types/
we will inspect the Type.Schema.required list to determine if
a property is required

Refactored makeWriteableType to push more creation logic into
WriteType in order to be able to centralize the decision of
whether a property is required or not inside the Property class.