### PR TITLE
Read credentials from env variables

### DIFF
--- a/python/looker_sdk/looker-sample.ini
+++ b/python/looker_sdk/looker-sample.ini
@@ -9,9 +9,5 @@ client_id=your_API3_client_id
 client_secret=your_API3_client_secret
 # Optional embed secret for SSO embedding
 embed_secret=your_embed_SSO_secret
-# Optional user_id to impersonate
-user_id=
 # Set to false if testing locally against self-signed certs. Otherwise leave True
 verify_ssl=True
-# leave verbose off by default
-verbose=false

--- a/python/looker_sdk/rtl/api_settings.py
+++ b/python/looker_sdk/rtl/api_settings.py
@@ -49,15 +49,18 @@ class ApiSettings(transport.TransportSettings):
         cfg = dict(cfg_parser[section])
 
         env_base_url = cast(str, os.getenv("LOOKER_BASE_URL"))
-        env_client_id = cast(str, os.getenv("LOOKER_CLIENT_ID"))
-        env_client_secret = cast(str, os.getenv("LOOKER_CLIENT_SECRET"))
-        env_embed_secret = cast(str, os.getenv("LOOKER_EMBED_SECRET"))
         if env_base_url:
             cfg["base_url"] = env_base_url
+
+        env_client_id = cast(str, os.getenv("LOOKER_CLIENT_ID"))
         if env_client_id:
             cfg["client_id"] = env_client_id
+
+        env_client_secret = cast(str, os.getenv("LOOKER_CLIENT_SECRET"))
         if env_client_secret:
             cfg["client_secret"] = env_client_secret
+
+        env_embed_secret = cast(str, os.getenv("LOOKER_EMBED_SECRET"))
         if env_embed_secret:
             cfg["embed_secret"] = env_embed_secret
 

--- a/python/looker_sdk/rtl/api_settings.py
+++ b/python/looker_sdk/rtl/api_settings.py
@@ -3,7 +3,7 @@ with the settings as attributes
 """
 import configparser as cp
 import os
-from typing import cast, Optional
+from typing import cast, Dict, Optional
 
 import attr
 import cattr
@@ -25,52 +25,73 @@ def _convert_bool(val: str, _: bool) -> bool:
 @attr.s(auto_attribs=True, kw_only=True)
 class ApiSettings(transport.TransportSettings):
     """API Configuration Settings.
+
+    This class can be instantiated directly to provide settings.
+    See the configure() method below which provides a convenient
+    entry point using a config file and/or environment variables.
+
+    Note that the parent class also has non-default fields that
+    need to be supplied.
     """
 
     client_id: str
     client_secret: str
     embed_secret: str = ""
-    # User ID to impersonate (optional)
-    user_id: str = ""
-    verbose: bool = False
 
     @classmethod
     def configure(
         cls, filename: str = "looker.ini", section: Optional[str] = None
     ) -> "ApiSettings":
-        """ApiSettings with attributes configured as per config file.
+        """Configure using a config file and/or environment variables.
+
+        Environment variables will override config file settings. Neither
+        is necessary but some combination must supply the minimum to
+        instantiate ApiSettings.
+
+        ENV variables map like this:
+            LOOKER_BASE_URL -> base_url
+            LOOKER_CLIENT_ID -> client_id
+            LOOKER_CLIENT_SECRET -> client_secret
+            LOOKER_EMBED_SECRET -> embed_secret
+
         """
         cfg_parser = cp.ConfigParser()
-        cfg_parser.read_file(open(filename))
-
-        # If section is not specified, use first section in file
-        section = section or cfg_parser.sections()[0]
-
-        cfg = dict(cfg_parser[section])
+        try:
+            cfg_parser.read_file(open(filename))
+        except FileNotFoundError:
+            config_data: Dict[str, str] = {}
+        else:
+            # If section is not specified, use first section in file
+            section = section or cfg_parser.sections()[0]
+            config_data = dict(cfg_parser[section])
 
         env_base_url = cast(str, os.getenv("LOOKER_BASE_URL"))
         if env_base_url:
-            cfg["base_url"] = env_base_url
+            config_data["base_url"] = env_base_url
 
         env_client_id = cast(str, os.getenv("LOOKER_CLIENT_ID"))
         if env_client_id:
-            cfg["client_id"] = env_client_id
+            config_data["client_id"] = env_client_id
 
         env_client_secret = cast(str, os.getenv("LOOKER_CLIENT_SECRET"))
         if env_client_secret:
-            cfg["client_secret"] = env_client_secret
+            config_data["client_secret"] = env_client_secret
 
         env_embed_secret = cast(str, os.getenv("LOOKER_EMBED_SECRET"))
         if env_embed_secret:
-            cfg["embed_secret"] = env_embed_secret
+            config_data["embed_secret"] = env_embed_secret
+
+        api_version = cast(str, os.getenv("LOOKER_API_VERSION"))
+        if api_version:
+            config_data["api_version"] = api_version
 
         # Remove required params from config dictionary if they are empty strings
         required_params = ["base_url", "client_id", "client_secret"]
-        for key, val in list(cfg.items()):
+        for key, val in list(config_data.items()):
             if key in required_params and not val:
-                cfg.pop(key)
+                config_data.pop(key)
 
         converter = cattr.Converter()
         converter.register_structure_hook(bool, _convert_bool)
-        settings: ApiSettings = converter.structure(cfg, cls)
+        settings: ApiSettings = converter.structure(config_data, cls)
         return settings

--- a/python/looker_sdk/rtl/api_settings.py
+++ b/python/looker_sdk/rtl/api_settings.py
@@ -2,7 +2,8 @@
 with the settings as attributes
 """
 import configparser as cp
-from typing import Optional
+import os
+from typing import cast, Optional
 
 import attr
 import cattr
@@ -46,6 +47,25 @@ class ApiSettings(transport.TransportSettings):
         section = section or cfg_parser.sections()[0]
 
         cfg = dict(cfg_parser[section])
+
+        env_base_url = cast(str, os.getenv("LOOKER_BASE_URL"))
+        env_client_id = cast(str, os.getenv("LOOKER_CLIENT_ID"))
+        env_client_secret = cast(str, os.getenv("LOOKER_CLIENT_SECRET"))
+        env_embed_secret = cast(str, os.getenv("LOOKER_EMBED_SECRET"))
+        if env_base_url:
+            cfg["base_url"] = env_base_url
+        if env_client_id:
+            cfg["client_id"] = env_client_id
+        if env_client_secret:
+            cfg["client_secret"] = env_client_secret
+        if env_embed_secret:
+            cfg["embed_secret"] = env_embed_secret
+
+        # Remove required params from config dictionary if they are empty strings
+        required_params = ["base_url", "client_id", "client_secret"]
+        for key, val in list(cfg.items()):
+            if key in required_params and not val:
+                cfg.pop(key)
 
         converter = cattr.Converter()
         converter.register_structure_hook(bool, _convert_bool)

--- a/python/looker_sdk/rtl/api_settings.py
+++ b/python/looker_sdk/rtl/api_settings.py
@@ -22,17 +22,17 @@ def _convert_bool(val: str, _: bool) -> bool:
     return converted
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, kw_only=True)
 class ApiSettings(transport.TransportSettings):
     """API Configuration Settings.
     """
 
-    client_id: str = attr.ib(kw_only=True)
-    client_secret: str = attr.ib(kw_only=True)
-    embed_secret: str = attr.ib(default="", kw_only=True)
+    client_id: str
+    client_secret: str
+    embed_secret: str = ""
     # User ID to impersonate (optional)
-    user_id: str = attr.ib(default="", kw_only=True)
-    verbose: bool = attr.ib(default=False, kw_only=True)
+    user_id: str = ""
+    verbose: bool = False
 
     @classmethod
     def configure(

--- a/python/looker_sdk/rtl/transport.py
+++ b/python/looker_sdk/rtl/transport.py
@@ -20,7 +20,7 @@ class HttpMethod(enum.Enum):
     HEAD = 7
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, kw_only=True)
 class TransportSettings:
     """Basic transport settings.
     """

--- a/python/tests/rtl/test_api_settings.py
+++ b/python/tests/rtl/test_api_settings.py
@@ -50,6 +50,10 @@ client_secret=myclientsecret
 base_url=https://host3.looker.com:19999/
 client_id=""
 client_secret=
+
+[MISSING_BASE_URL]
+client_id=your_API3_client_id
+client_secret=your_API3_client_secret
 """
     )
     return filename
@@ -162,6 +166,7 @@ def test_credentials_are_read_from_env_variables(
     [
         pytest.param("BARE", id="Empty config file"),
         pytest.param("BARE_MIN_NO_VALUES", id="Required settings are empty strings"),
+        pytest.param("MISSING_BASE_URL", id="Missing base url"),
     ],
 )
 def test_it_fails_if_required_settings_are_not_found(config_file, test_section):

--- a/python/tests/rtl/test_api_settings.py
+++ b/python/tests/rtl/test_api_settings.py
@@ -6,14 +6,14 @@ import pytest  # type: ignore
 from looker_sdk.rtl import api_settings
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def config_file(tmpdir_factory):
     """Creates a sample looker.ini file and returns its path"""
     filename = tmpdir_factory.mktemp("settings").join("looker.ini")
     filename.write(
         """
 [Looker]
-# API version is required
+# API version
 api_version=3.1
 # Base URL for API. Do not include /api/* in the url
 base_url=https://host1.looker.com:19999
@@ -30,7 +30,7 @@ verify_ssl=True
 # leave verbose off by default
 verbose=false
 
-[Looker2]
+[OLD_API]
 api_version=3.0
 base_url=https://host2.looker.com:19999
 client_id=your_API3_client_id
@@ -39,39 +39,53 @@ embed_secret=your_embed_SSO_secret
 user_id=
 verify_ssl=True
 
-[Looker3]
+[BARE_MINIMUM]
 base_url=https://host3.looker.com:19999/
 client_id=myclientid
 client_secret=myclientsecret
-        """
+
+[BARE]
+# Empty section
+[BARE_MIN_NO_VALUES]
+base_url=https://host3.looker.com:19999/
+client_id=""
+client_secret=
+"""
     )
     return filename
 
 
 def test_settings_defaults_to_looker_section(config_file):
     """ApiSettings should retrieve settings from default (Looker) section
-    if section is not specified during instantiation."""
+    if section is not specified during instantiation.
+    """
     settings = api_settings.ApiSettings.configure(config_file)
     assert settings.base_url == "https://host1.looker.com:19999"
 
 
 @pytest.mark.parametrize(
-    "test_section, expected_url",
+    "test_section, expected_url, expected_api_version",
     [
-        ("Looker", "https://host1.looker.com:19999"),
-        ("Looker2", "https://host2.looker.com:19999"),
+        ("Looker", "https://host1.looker.com:19999", "3.1"),
+        ("OLD_API", "https://host2.looker.com:19999", "3.0"),
     ],
-    ids=["section=Looker", "section=Looker2"],
+    ids=["section=Looker", "section=OLD_API"],
 )
-def test_it_retrieves_section_by_name(config_file, test_section, expected_url):
-    """ApiSettings should return settings of specified section."""
+def test_it_retrieves_section_by_name(
+    config_file, test_section, expected_url, expected_api_version
+):
+    """ApiSettings should return settings of specified section.
+    """
     settings = api_settings.ApiSettings.configure(config_file, test_section)
     assert settings.base_url == expected_url
+    assert settings.api_version == expected_api_version
 
 
 def test_it_assigns_defaults_to_empty_settings(config_file):
-    """ApiSettings assigns Nones to optional settings that are empty in the config file"""
-    settings = api_settings.ApiSettings.configure(config_file, "Looker3")
+    """ApiSettings assigns Nones to optional settings that are empty in the
+    config file.
+    """
+    settings = api_settings.ApiSettings.configure(config_file, "BARE_MINIMUM")
     assert settings.api_version == "3.1"
     assert settings.base_url == "https://host3.looker.com:19999/"
     assert settings.client_id == "myclientid"
@@ -99,12 +113,69 @@ def test_it_fails_with_a_bad_filename():
 @pytest.mark.parametrize(
     "test_url, expected_url",
     [
-        ("https://host1.looker.com:19999", "https://host1.looker.com:19999/api/3.1"),
-        ("https://host1.looker.com:19999/", "https://host1.looker.com:19999/api/3.1"),
+        pytest.param(
+            "https://host1.looker.com:19999",
+            "https://host1.looker.com:19999/api/3.1",
+            id="Without trailing forward slash",
+        ),
+        pytest.param(
+            "https://host1.looker.com:19999/",
+            "https://host1.looker.com:19999/api/3.1",
+            id="With trailing forward slash",
+        ),
     ],
 )
 def test_versioned_api_url_is_built_properly(config_file, test_url, expected_url):
-    """ApiSettings.url should append the api version to the base url"""
+    """ApiSettings.url should append the api version to the base url.
+    """
     settings = api_settings.ApiSettings.configure(config_file)
     settings.base_url = test_url
     assert settings.url == expected_url
+
+
+@pytest.mark.parametrize(
+    "test_section",
+    [
+        pytest.param("BARE", id="Empty config file"),
+        pytest.param("BARE_MINIMUM", id="Overriding with env variables"),
+    ],
+)
+def test_credentials_are_read_from_env_variables(
+    monkeypatch, config_file, test_section
+):
+    """ApiSettings should read settings defined as env variables.
+    """
+    monkeypatch.setenv("LOOKER_BASE_URL", "https://host1.looker.com:19999")
+    monkeypatch.setenv("LOOKER_CLIENT_ID", "id123")
+    monkeypatch.setenv("LOOKER_CLIENT_SECRET", "secret123")
+    monkeypatch.setenv("LOOKER_EMBED_SECRET", "embedsecret123")
+
+    settings = api_settings.ApiSettings.configure(config_file, section=test_section)
+    assert settings.base_url == "https://host1.looker.com:19999"
+    assert settings.client_id == "id123"
+    assert settings.client_secret == "secret123"
+    assert settings.embed_secret == "embedsecret123"
+
+
+@pytest.mark.parametrize(
+    "test_section",
+    [
+        pytest.param("BARE", id="Empty config file"),
+        pytest.param("BARE_MIN_NO_VALUES", id="Required settings are empty strings"),
+    ],
+)
+def test_it_fails_if_required_settings_are_not_found(config_file, test_section):
+    """ApiSettings should throw an error if required settings are not found.
+    """
+    with pytest.raises(TypeError):
+        api_settings.ApiSettings.configure(config_file, test_section)
+
+
+def test_it_fails_when_env_variables_are_defined_but_empty(config_file, monkeypatch):
+    """ApiSettings should throw an error if env variables are defined but empty.
+    """
+    monkeypatch.setenv("LOOKER_CLIENT_ID", "")
+    monkeypatch.setenv("LOOKER_CLIENT_SECRET", "")
+
+    with pytest.raises(TypeError):
+        api_settings.ApiSettings.configure(config_file, "BARE_MIN_NO_VALUES")

--- a/python/tests/rtl/test_user_session.py
+++ b/python/tests/rtl/test_user_session.py
@@ -31,8 +31,6 @@ client_secret=your_API3_client_secret
 embed_secret=your_embed_SSO_secret
 # Set to false if testing locally against self-signed certs. Otherwise leave True
 verify_ssl=True
-# leave verbose off by default
-verbose=false
         """
     )
     return filename


### PR DESCRIPTION
Allow users to pass LOOKER_BASE_URL, LOOKER_CLIENT_ID, LOOKER_CLIENT_SECRET and LOOKER_EMBED_SECRET as env variables.

If settings are defined in both the config file and env variables, then the latter will override the config file settings.