### PR TITLE
Python: stamp looker/api version for user-agent

### DIFF
--- a/python/Pipfile.lock
+++ b/python/Pipfile.lock
@@ -33,10 +33,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
-                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
+                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
             ],
-            "version": "==2019.6.16"
+            "version": "==2019.9.11"
         },
         "chardet": {
             "hashes": [
@@ -123,10 +123,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
-                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
+                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
             ],
-            "version": "==2019.6.16"
+            "version": "==2019.9.11"
         },
         "chardet": {
             "hashes": [
@@ -234,11 +234,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:0c505102757e7fa28b9f0958d8bc81301159dea16e2649858c92edc158b78a83",
-                "sha256:9a9f75ce32e78170905888acbf2376a81d3f21ecb3bb4867050413411d3ca7a9"
+                "sha256:652234b6ab8f2506ae58e528b6fbcc668831d3cc758e1bc01ef438d328b68cdb",
+                "sha256:6f264986fb88042bc1f0535fa9a557e6a376cfe5679dc77caac7fe8b5d43d05f"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==0.21"
+            "version": "==0.22"
         },
         "ipython": {
             "hashes": [
@@ -338,10 +338,10 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
-                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
+                "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6",
+                "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"
             ],
-            "version": "==0.12.0"
+            "version": "==0.13.0"
         },
         "prettyprinter": {
             "hashes": [

--- a/python/looker_sdk/rtl/api_settings.py
+++ b/python/looker_sdk/rtl/api_settings.py
@@ -10,6 +10,7 @@ import cattr
 
 from looker_sdk import error
 from looker_sdk.rtl import transport
+from looker_sdk.rtl import versions
 
 
 def _convert_bool(val: str, _: bool) -> bool:
@@ -49,22 +50,26 @@ class ApiSettings(transport.TransportSettings):
         instantiate ApiSettings.
 
         ENV variables map like this:
-            LOOKER_BASE_URL -> base_url
-            LOOKER_API_VERSION -> api_version
-            LOOKER_VERIFY_SSL -> verify_ssl
+            <package-prefix>_API_VERSION -> api_version
+            <package-prefix>_BASE_URL -> base_url
+            <package-prefix>_VERIFY_SSL -> verify_ssl
         """
 
         config_data = cls.read_ini(filename, section)
 
-        env_base_url = cast(str, os.getenv("LOOKER_BASE_URL"))
-        if env_base_url:
-            config_data["base_url"] = env_base_url
-
-        env_api_version = cast(str, os.getenv("LOOKER_API_VERSION"))
+        env_api_version = cast(
+            str, os.getenv(f"{versions.environment_prefix}_API_VERSION")
+        )
         if env_api_version:
             config_data["api_version"] = env_api_version
 
-        env_verify_ssl = cast(str, os.getenv("LOOKER_VERIFY_SSL"))
+        env_base_url = cast(str, os.getenv(f"{versions.environment_prefix}_BASE_URL"))
+        if env_base_url:
+            config_data["base_url"] = env_base_url
+
+        env_verify_ssl = cast(
+            str, os.getenv(f"{versions.environment_prefix}_VERIFY_SSL")
+        )
         if env_verify_ssl:
             config_data["verify_ssl"] = env_verify_ssl
 

--- a/python/looker_sdk/rtl/auth_session.py
+++ b/python/looker_sdk/rtl/auth_session.py
@@ -9,6 +9,7 @@ from looker_sdk.rtl import api_settings
 from looker_sdk.rtl import auth_token
 from looker_sdk.rtl import transport
 from looker_sdk.rtl import serialize
+from looker_sdk.rtl import versions
 from looker_sdk.sdk import models
 
 
@@ -99,10 +100,12 @@ class AuthSession:
         config_data = self.settings.read_ini(
             self.settings._filename, self.settings._section
         )
-        client_id = os.getenv("LOOKER_CLIENT_ID") or config_data.get("client_id")
-        client_secret = os.getenv("LOOKER_CLIENT_SECRET") or config_data.get(
-            "client_secret"
-        )
+        client_id = os.getenv(
+            f"{versions.environment_prefix}_CLIENT_ID"
+        ) or config_data.get("client_id")
+        client_secret = os.getenv(
+            f"{versions.environment_prefix}_CLIENT_SECRET"
+        ) or config_data.get("client_secret")
 
         if not (client_id and client_secret):
             raise error.SDKError("Required auth credentials not found.")

--- a/python/looker_sdk/rtl/requests_transport.py
+++ b/python/looker_sdk/rtl/requests_transport.py
@@ -17,7 +17,7 @@ class RequestsTransport(transport.Transport):
         self, settings: transport.TransportSettings, session: requests.Session
     ):
 
-        headers: Dict[str, str] = {}
+        headers: Dict[str, str] = {"User-Agent": settings.agent_tag}
         if settings.headers:
             headers.update(settings.headers)
         session.headers.update(headers)

--- a/python/looker_sdk/rtl/transport.py
+++ b/python/looker_sdk/rtl/transport.py
@@ -6,6 +6,8 @@ from typing import Callable, Dict, MutableMapping, Optional, Union
 
 import attr
 
+from looker_sdk.rtl import versions
+
 
 class HttpMethod(enum.Enum):
     """Supported HTTP verbs.
@@ -35,6 +37,12 @@ class TransportSettings:
         """Create and return an API-versioned base endpoint.
         """
         return f'{self.base_url.rstrip("/")}/api/{self.api_version}'
+
+    @property
+    def agent_tag(self) -> str:
+        """User Agent value
+        """
+        return f"PY-SDK {versions.sdk_version}"
 
 
 TResponseValue = Union[str, bytes]

--- a/python/looker_sdk/rtl/versions.py
+++ b/python/looker_sdk/rtl/versions.py
@@ -1,3 +1,4 @@
 looker_version = "6.19"
 api_version = "3.1"
 sdk_version = f"{api_version}.{looker_version}"
+environment_prefix = "LOOKERSDK"

--- a/python/looker_sdk/rtl/versions.py
+++ b/python/looker_sdk/rtl/versions.py
@@ -1,0 +1,3 @@
+looker_version = "6.19"
+api_version = "3.1"
+sdk_version = f"{api_version}.{looker_version}"

--- a/python/tests/rtl/test_api_settings.py
+++ b/python/tests/rtl/test_api_settings.py
@@ -131,11 +131,11 @@ def test_settings_from_env_variables_override_config_file(
 ):
     """ApiSettings should read settings defined as env variables.
     """
-    monkeypatch.setenv("LOOKER_BASE_URL", "https://host1.looker.com:19999")
-    monkeypatch.setenv("LOOKER_API_VERSION", "3.0")
-    monkeypatch.setenv("LOOKER_VERIFY_SSL", "0")
-    monkeypatch.setenv("LOOKER_CLIENT_ID", "id123")
-    monkeypatch.setenv("LOOKER_CLIENT_SECRET", "secret123")
+    monkeypatch.setenv("LOOKERSDK_BASE_URL", "https://host1.looker.com:19999")
+    monkeypatch.setenv("LOOKERSDK_API_VERSION", "3.0")
+    monkeypatch.setenv("LOOKERSDK_VERIFY_SSL", "0")
+    monkeypatch.setenv("LOOKERSDK_CLIENT_ID", "id123")
+    monkeypatch.setenv("LOOKERSDK_CLIENT_SECRET", "secret123")
 
     settings = api_settings.ApiSettings.configure(config_file, section=test_section)
     assert settings.base_url == "https://host1.looker.com:19999"
@@ -165,7 +165,7 @@ def test_env_verify_ssl_maps_properly(monkeypatch, config_file, test_value, expe
     """ApiSettings should map the various values that VERIFY_SSL can take to True/False
     accordingly.
     """
-    monkeypatch.setenv("LOOKER_VERIFY_SSL", test_value)
+    monkeypatch.setenv("LOOKERSDK_VERIFY_SSL", test_value)
     settings = api_settings.ApiSettings.configure(config_file, section="BARE_MINIMUM")
     assert settings.verify_ssl == expected
 
@@ -174,9 +174,9 @@ def test_configure_with_no_file(monkeypatch):
     """ApiSettings should be instantiated if required parameters all exist in env
     variables.
     """
-    monkeypatch.setenv("LOOKER_BASE_URL", "https://host1.looker.com:19999")
-    monkeypatch.setenv("LOOKER_CLIENT_ID", "id123")
-    monkeypatch.setenv("LOOKER_CLIENT_SECRET", "secret123")
+    monkeypatch.setenv("LOOKERSDK_BASE_URL", "https://host1.looker.com:19999")
+    monkeypatch.setenv("LOOKERSDK_CLIENT_ID", "id123")
+    monkeypatch.setenv("LOOKERSDK_CLIENT_SECRET", "secret123")
 
     settings = api_settings.ApiSettings.configure("no-such-file")
     assert settings.base_url == "https://host1.looker.com:19999"
@@ -202,7 +202,7 @@ def test_it_fails_when_env_variables_are_defined_but_empty(config_file, monkeypa
     """ApiSettings should throw an error if required settings are passed as empty
     env variables.
     """
-    monkeypatch.setenv("LOOKER_BASE_URL", "")
+    monkeypatch.setenv("LOOKERSDK_BASE_URL", "")
 
     with pytest.raises(error.SDKError):
         api_settings.ApiSettings.configure(config_file, "BARE")

--- a/python/tests/rtl/test_auth_session.py
+++ b/python/tests/rtl/test_auth_session.py
@@ -149,8 +149,8 @@ def test_is_sudo(auth_session: auth.AuthSession):
 def test_it_fails_with_missing_credentials(
     config_file, monkeypatch, test_section, test_env_client_id, test_env_client_secret
 ):
-    monkeypatch.setenv("LOOKER_CLIENT_ID", test_env_client_id)
-    monkeypatch.setenv("LOOKER_CLIENT_SECRET", test_env_client_secret)
+    monkeypatch.setenv("LOOKERSDK_CLIENT_ID", test_env_client_id)
+    monkeypatch.setenv("LOOKERSDK_CLIENT_SECRET", test_env_client_secret)
 
     settings = api_settings.ApiSettings.configure(config_file, test_section)
     auth_session = auth.AuthSession(
@@ -178,8 +178,8 @@ def test_env_variables_override_config_file_credentials(
     expected_id,
     expected_secret,
 ):
-    monkeypatch.setenv("LOOKER_CLIENT_ID", test_env_client_id)
-    monkeypatch.setenv("LOOKER_CLIENT_SECRET", test_env_client_secret)
+    monkeypatch.setenv("LOOKERSDK_CLIENT_ID", test_env_client_id)
+    monkeypatch.setenv("LOOKERSDK_CLIENT_SECRET", test_env_client_secret)
     mocked_request = mocker.patch.object(MockTransport, "request")
     mocked_request.return_value = transport.Response(
         ok=True,

--- a/python/tests/rtl/test_requests_transport.py
+++ b/python/tests/rtl/test_requests_transport.py
@@ -1,8 +1,9 @@
 import attr
 import pytest  # type: ignore
 
-from looker_sdk.rtl import transport
 from looker_sdk.rtl import requests_transport
+from looker_sdk.rtl import transport
+from looker_sdk.rtl import versions
 
 
 @attr.s(auto_attribs=True)
@@ -45,6 +46,7 @@ def test_configure(settings):
 
     test = requests_transport.RequestsTransport.configure(settings)
     assert isinstance(test, requests_transport.RequestsTransport)
+    assert test.session.headers.get("User-Agent") == f"PY-SDK {versions.sdk_version}"
 
 
 def test_request_ok(settings):

--- a/src/python.gen.ts
+++ b/src/python.gen.ts
@@ -360,8 +360,10 @@ ${this.hooks.join('\n')}
       let content = fs.readFileSync(stampFile, utf8)
       const lookerPattern = /looker_version = ['"]\d+\.\d+['"]/i
       const apiPattern = /api_version = ['"]\d+\.\d+['"]/i
+      const envPattern = /environment_prefix = ['"]\w+['"]/i
       content = content.replace(lookerPattern, `looker_version = "${this.versions.lookerVersion}"`)
       content = content.replace(apiPattern, `api_version = "${this.versions.apiVersion}"`)
+      content = content.replace(envPattern, `environment_prefix = "${this.packageName.toUpperCase()}"`)
       fs.writeFileSync(stampFile, content, {encoding: utf8})
       success(`updated ${stampFile} to ${this.versions.apiVersion}.${this.versions.lookerVersion}` )
     } else {

--- a/src/python.gen.ts
+++ b/src/python.gen.ts
@@ -37,7 +37,8 @@ import {
   WriteType,
 } from './sdkModels'
 import { CodeGen, warnEditing } from './codeGen'
-import { run } from './utils'
+import * as fs from 'fs'
+import { run, warn, isFileSync, utf8, success } from './utils'
 
 export class PythonGen extends CodeGen {
   codePath = './python/'
@@ -351,18 +352,21 @@ ${this.hooks.join('\n')}
   }
 
   versionStamp() {
-    // if (this.versions) {
-    //   const stampFile = this.fileName('rtl/versions')
-    //   if (!isFileSync(stampFile)) {
-    //     warn(`${stampFile} was not found. Skipping version update to ${this.versions.apiVersion}.${this.versions.lookerVersion}`)
-    //   }
-    //   let content = fs.readFileSync(stampFile, utf8)
-    //   const lookerPattern = /lookerVersion = '\d+\.\d+'/i
-    //   const apiPattern = /apiVersion = '\d+\.\d+'/i
-    //   content = content.replace(lookerPattern, `lookerVersion = ${this.versions.lookerVersion}`)
-    //   content = content.replace(apiPattern, `apiVersion = ${this.versions.apiVersion}`)
-    //   fs.writeFileSync(stampFile, content, {encoding: utf8})
-    // }
+    if (this.versions) {
+      const stampFile = this.fileName('rtl/versions')
+      if (!isFileSync(stampFile)) {
+        warn(`${stampFile} was not found. Skipping version update.`)
+      }
+      let content = fs.readFileSync(stampFile, utf8)
+      const lookerPattern = /looker_version = ['"]\d+\.\d+['"]/i
+      const apiPattern = /api_version = ['"]\d+\.\d+['"]/i
+      content = content.replace(lookerPattern, `looker_version = "${this.versions.lookerVersion}"`)
+      content = content.replace(apiPattern, `api_version = "${this.versions.apiVersion}"`)
+      fs.writeFileSync(stampFile, content, {encoding: utf8})
+      success(`updated ${stampFile} to ${this.versions.apiVersion}.${this.versions.lookerVersion}` )
+    } else {
+      warn('Version information was not retrieved. Skipping SDK version updating.')
+    }
     return this.versions
   }
 

--- a/src/typescript.gen.ts
+++ b/src/typescript.gen.ts
@@ -276,7 +276,7 @@ export interface IDictionary<T> {
       let content = fs.readFileSync(stampFile, utf8)
       const lookerPattern = /lookerVersion = ['"]\d+\.\d+['"]/i
       const apiPattern = /apiVersion = ['"]\d+\.\d+['"]/i
-      const envPattern = /environmentPrefix = ['"]\d+\.\d+['"]/i
+      const envPattern = /environmentPrefix = ['"]\w+['"]/i
       content = content.replace(lookerPattern, `lookerVersion = '${this.versions.lookerVersion}'`)
       content = content.replace(apiPattern, `apiVersion = '${this.versions.apiVersion}'`)
       content = content.replace(envPattern, `environmentPrefix = '${this.packageName.toUpperCase()}'`)

--- a/typescript/looker/rtl/apiSettings.spec.ts
+++ b/typescript/looker/rtl/apiSettings.spec.ts
@@ -22,7 +22,15 @@
  * THE SOFTWARE.
  */
 
-import { ApiSettings, strBadConfiguration, ValueSettings } from './apiSettings'
+import {
+  ApiSettings,
+  strBadConfiguration,
+  ValueSettings,
+  strLookerApiVersion,
+  strLookerBaseUrl,
+  strLookerVerifySsl,
+  strLookerTimeout
+} from './apiSettings'
 import { defaultTimeout } from './transport'
 
 describe('SDK configuration', () => {
@@ -37,10 +45,10 @@ describe('SDK configuration', () => {
 
     it('retrieves the first section by name', () => {
       const settings = ValueSettings({
-        LOOKER_API_VERSION: '3.0',
-        LOOKER_BASE_URL: 'base',
-        LOOKER_VERIFY_SSL: 'false',
-        LOOKER_TIMEOUT: '30',
+        [strLookerApiVersion]: '3.0',
+        [strLookerBaseUrl]: 'base',
+        [strLookerVerifySsl]: 'false',
+        [strLookerTimeout]: '30',
       })
       expect(settings.api_version).toEqual('3.0')
       expect(settings.base_url).toEqual('base')

--- a/typescript/looker/rtl/apiSettings.ts
+++ b/typescript/looker/rtl/apiSettings.ts
@@ -59,12 +59,12 @@ export const DefaultSettings = () =>
  * @constructor
  *
  * The values keys are:
- *  - LOOKER_BASE_URL
- *  - LOOKER_API_VERSION
- *  - LOOKER_CLIENT_ID
- *  - LOOKER_CLIENT_SECRET
- *  - LOOKER_VERIFY_SSL
- *  - LOOKER_TIMEOUT
+ *  - <environmentPrefix>_BASE_URL
+ *  - <environmentPrefix>_API_VERSION
+ *  - <environmentPrefix>_CLIENT_ID
+ *  - <environmentPrefix>_CLIENT_SECRET
+ *  - <environmentPrefix>_VERIFY_SSL
+ *  - <environmentPrefix>_TIMEOUT
  */
 export const ValueSettings = (values: IValueSettings): IApiSettings => {
   const settings = DefaultSettings()

--- a/typescript/looker/rtl/nodeSession.ts
+++ b/typescript/looker/rtl/nodeSession.ts
@@ -33,12 +33,13 @@ import {
 import { AuthToken } from './authToken'
 import { NodeTransport } from './nodeTransport'
 import { IApiSettingsIniFile } from './nodeSettings'
+import { environmentPrefix } from './versions'
 
 const strPost = 'POST'
 const strDelete = 'DELETE'
 
-const strLookerClientId = 'LOOKER_CLIENT_ID'
-const strLookerClientSecret = 'LOOKER_CLIENT_SECRET'
+const strLookerClientId = `${environmentPrefix}_CLIENT_ID`
+const strLookerClientSecret = `${environmentPrefix}_CLIENT_SECRET`
 
 /**
  * Same as the Looker API access token object

--- a/typescript/looker/rtl/versions.ts
+++ b/typescript/looker/rtl/versions.ts
@@ -25,4 +25,4 @@
 export const lookerVersion = '6.19'
 export const apiVersion = '3.1'
 export const sdkVersion = `${apiVersion}.${lookerVersion}`
-export const environmentPrefix = 'LOOKER'
+export const environmentPrefix = 'LOOKERSDK'

--- a/typescript/looker/rtl/versions.ts
+++ b/typescript/looker/rtl/versions.ts
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 
-export const lookerVersion = 'undefined'
-export const apiVersion = 'undefined'
+export const lookerVersion = '6.19'
+export const apiVersion = '3.1'
 export const sdkVersion = `${apiVersion}.${lookerVersion}`
 export const environmentPrefix = 'LOOKER'


### PR DESCRIPTION
For the codegen this is currently almost an exact copy of the typescript
generator with variable names snake_cased for python style. Might be
worth abstracting those variables out into config and moving the method
implementation into the base class.

For the python rtl - added User-Agent header like "PY-SDK 3.1.6.19". We
might want to also consider the same prefixing strategy we plan for
environment variable config here as well. (e.g. we'd be "LOOKER-PY-SDK
3.1.6.19")